### PR TITLE
#1 Deal with source as a path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/*
 .vscode/*
 .pytest_cache/*
 .tox/*
+coverage/*

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build/*
 .pytest_cache/*
 .tox/*
 coverage/*
+.coverage

--- a/tests/test_realreq.py
+++ b/tests/test_realreq.py
@@ -27,6 +27,7 @@ from . import local_module
 import local_module2
 from foo.baz import frum
 import abbrev
+import src.local_module
 """
 
 MOCK_ALIASES = {"abbrev": "abbreviation"}
@@ -86,15 +87,18 @@ def mock_pip_freeze(*args, **kwargs):
 
 @pytest.fixture(scope="session")
 def source_files(tmp_path_factory):
-    src = tmp_path_factory.mktemp("src")
-    main = src / "main.py"
-    main.write_text(CONTENT)
-    return src
+    def source_dir(dir_path):
+        src = tmp_path_factory.mktemp("src")
+        main = src / "main.py"
+        main.write_text(CONTENT)
+        return src
+
+    return source_dir
 
 
 def test_search_source_for_used_packages(source_files):
     """Source code is searched and aquires the name of all packages used"""
-    pkgs = realreq._search_source(str(source_files))
+    pkgs = realreq._search_source(str(source_files("src")))
     expected = ["requests", "foo", "local_module2", "abbreviation"]
     assert all([_ in pkgs for _ in expected])
 

--- a/tests/test_realreq.py
+++ b/tests/test_realreq.py
@@ -1,11 +1,4 @@
 # Copyright 2020 Tyler Calder
-
-# Design my Requirements
-# I want to be able to search all source code to find used packages
-# in the code
-# I then want to take the ones found and check in the list of installed
-# and then check their dependencies and then write
-# packages and send them to the std out
 import unittest.mock
 import os
 import subprocess
@@ -85,22 +78,37 @@ def mock_pip_freeze(*args, **kwargs):
     return mock_result
 
 
-@pytest.fixture(scope="session")
-def source_files(tmp_path_factory):
-    def source_dir(dir_path):
-        src = tmp_path_factory.mktemp("src")
-        main = src / "main.py"
-        main.write_text(CONTENT)
-        return src
-
-    return source_dir
+@pytest.fixture(scope="session", params=["src", "path/to/src"])
+def source_files(
+    tmp_path_factory, request,
+):
+    path = os.path.normpath(request.param)
+    paths = path.split("/")
+    if len(paths) > 1 and isinstance(paths, list):
+        src = tmp_path_factory.mktemp(path[0], numbered=False)
+        print(paths)
+        for p in paths:
+            src = src / p
+            src.mkdir()
+    else:
+        src = tmp_path_factory.mktemp(path, numbered=False)
+    main = src / "main.py"
+    main.write_text(CONTENT)
+    print(src)
+    return src
 
 
 def test_search_source_for_used_packages(source_files):
     """Source code is searched and aquires the name of all packages used"""
-    pkgs = realreq._search_source(str(source_files("src")))
-    expected = ["requests", "foo", "local_module2", "abbreviation"]
-    assert all([_ in pkgs for _ in expected])
+    print(source_files)
+    pkgs = realreq._search_source(str(source_files))
+    expected = [
+        "requests",
+        "foo",
+        "local_module2",
+        "abbreviation",
+    ]
+    assert set(pkgs) == set(expected)
 
 
 def test_build_dependency_list(mocker):
@@ -131,4 +139,14 @@ def test_get_dependency_versions(mocker):
         "wheel": "1.1.1",
         "abbreviation": "1.2.1",
     }
+
+
+# class TestCLI:
+#     """Tests for the CLI of realreq"""
+
+#     def test_source_parameter_is_treated_as_path(self, source_files, mocker):
+#         args = ["-s", "/fake/path"]
+#         app = realreq._RealReq()
+#         app(args)
+#         assert False
 


### PR DESCRIPTION
**Description**

Makes handling of the `--source` parameter treat it like a pathlib.Path rather
than a string and access the final directory in the path as the name of the source module
when doing the filtering to eliminate the local module.

**changes**

- remove Coverage file
- Add test structure to test for paths
- Remove coverage info
- Fix path handling of source argument
