### PR TITLE
adding single file module functionality

### DIFF
--- a/_realreq/realreq.py
+++ b/_realreq/realreq.py
@@ -149,10 +149,7 @@ def search_source(source, aliases=ALIASES):
     imports = [m for m in imports if m not in STD_LIBS]
     imports = set(imports)
 
-    # TODO: this is where the fix needs to be added for modules vs directories
-    if is_module:
-        pass
-    source_module = source.stem
+    source_module = source.resolve().parent.stem if is_module else source.stem
     imports.discard(source_module)
     for import_name, install_name in aliases.items():
         if import_name in imports:

--- a/_realreq/realreq.py
+++ b/_realreq/realreq.py
@@ -121,7 +121,8 @@ def split_aliases(aliases: typing.List[str]) -> typing.Dict[str, str]:
 def search_source(source, aliases=ALIASES):
     """Go through the source directory and identify all modules"""
     source = pathlib.Path(source)
-    if source.is_file() and source.suffix.lower() == ".py":
+    is_module = source.is_file() and source.suffix.lower() == ".py"
+    if is_module:
         source_files = [source]
     else:
         source_files = list(source.rglob("*.[Pp][Yy]"))
@@ -148,6 +149,9 @@ def search_source(source, aliases=ALIASES):
     imports = [m for m in imports if m not in STD_LIBS]
     imports = set(imports)
 
+    # TODO: this is where the fix needs to be added for modules vs directories
+    if is_module:
+        pass
     source_module = source.stem
     imports.discard(source_module)
     for import_name, install_name in aliases.items():

--- a/_realreq/realreq.py
+++ b/_realreq/realreq.py
@@ -120,7 +120,11 @@ def split_aliases(aliases: typing.List[str]) -> typing.Dict[str, str]:
 
 def search_source(source, aliases=ALIASES):
     """Go through the source directory and identify all modules"""
-    source_files = list(pathlib.Path(source).rglob("*.[Pp][Yy]"))
+    source = pathlib.Path(source)
+    if source.is_file() and source.suffix.lower() == ".py":
+        source_files = [source]
+    else:
+        source_files = list(source.rglob("*.[Pp][Yy]"))
 
     imports = []
     for file_ in source_files:
@@ -144,7 +148,7 @@ def search_source(source, aliases=ALIASES):
     imports = [m for m in imports if m not in STD_LIBS]
     imports = set(imports)
 
-    source_module = pathlib.Path(source).stem
+    source_module = source.stem
     imports.discard(source_module)
     for import_name, install_name in aliases.items():
         if import_name in imports:

--- a/tests/test_realreq.py
+++ b/tests/test_realreq.py
@@ -147,7 +147,9 @@ def mock_subprocess_run(*args, **kwargs):
         return mock_pip_freeze(*args, **kwargs)
 
 
-@pytest.fixture(scope="session", params=["src", "path/to/src"])
+@pytest.fixture(
+    scope="session", params=["src", "path/to/src", "main.py", "path/to/main.py"]
+)
 def source_files(
     tmp_path_factory,
     request,
@@ -156,17 +158,29 @@ def source_files(
 
     returns: path to directory being used for test
     """
+    print()
+    print(tmp_path_factory, request)
     path = os.path.normpath(request.param)
+    print("path", path)
     paths = path.split("/")
-    if len(paths) > 1 and isinstance(paths, list):
+    print("paths", paths)
+    if ".py" in path:
+        print("new", request.param)
+        main = tmp_path_factory.mktemp(path, numbered=False)
+        main.write_text(CONTENT)
+
+    elif len(paths) > 1 and isinstance(paths, list):
         src = tmp_path_factory.mktemp(path[0], numbered=False)
         for p in paths:
             src = src / p
+            print(src)
             src.mkdir()
     else:
         src = tmp_path_factory.mktemp(path, numbered=False)
     main = src / "main.py"
+    print("main", main)
     main.write_text(CONTENT)
+    print()
     return src
 
 

--- a/tests/test_realreq.py
+++ b/tests/test_realreq.py
@@ -177,9 +177,8 @@ def source_files(
         src = tmp_path_factory.mktemp(path, numbered=False)
 
     if is_module:
-        module = src / module
-        module.write_text(CONTENT)
-        return module
+        src = src / module
+        src.write_text(CONTENT)
     else:
         main = src / "main.py"
         main.write_text(CONTENT)

--- a/tests/test_realreq.py
+++ b/tests/test_realreq.py
@@ -147,8 +147,6 @@ def mock_subprocess_run(*args, **kwargs):
         return mock_pip_freeze(*args, **kwargs)
 
 
-# NOTE: I originally had "path/to/main" as a new param, but it caused an error (I
-# think) when trying to overwrite "path/to" that was created from the "path/to/src" param
 @pytest.fixture(scope="session", params=["src", "path/to/src", "go/to/src/module.py"])
 def source_files(
     tmp_path_factory,
@@ -165,13 +163,11 @@ def source_files(
         module = paths[-1]
         paths = paths[:-1]
     if len(paths) > 1 and isinstance(paths, list):
-        # what is the significance of path[0] here, is that just a hack to have src initialized with something?
         src = tmp_path_factory.mktemp(path[0], numbered=False)
         for p in paths:
             src = src / p
             src.mkdir()
     elif is_module:
-        # NOTE: here I used the same path[0] hack as above for now
         src = tmp_path_factory.mktemp(path[0], numbered=False)
     else:
         src = tmp_path_factory.mktemp(path, numbered=False)

--- a/tests/test_realreq.py
+++ b/tests/test_realreq.py
@@ -149,9 +149,7 @@ def mock_subprocess_run(*args, **kwargs):
 
 # NOTE: I originally had "path/to/main" as a new param, but it caused an error (I
 # think) when trying to overwrite "path/to" that was created from the "path/to/src" param
-@pytest.fixture(
-    scope="session", params=["src", "path/to/src", "go/to/module.py", "module.py"]
-)
+@pytest.fixture(scope="session", params=["src", "path/to/src", "go/to/src/module.py"])
 def source_files(
     tmp_path_factory,
     request,

--- a/tests/test_realreq.py
+++ b/tests/test_realreq.py
@@ -4,7 +4,6 @@ import contextlib
 import io
 import unittest.mock
 import os
-import subprocess
 import sys
 
 import pytest


### PR DESCRIPTION
This PR is for addressing this issue: https://github.com/Calder-Ty/realreq/issues/2 

This change seemed to work for me. (ie I get the same results when running `realreq -s tests -d` vs ` realreq -s tests/test_realreq.py -d`


Image of matching results:

<img width="836" alt="image" src="https://user-images.githubusercontent.com/116472212/203905916-66f44759-24d5-4c20-a41b-47ded4722436.png">


~~I tried adding a few new test cases in the parameters to the test fixture for `source_files`, but wasn't able to get them to pass before I had to step away.  The test changes are in the draft (even though they aren't passing) so that you can take a look in case you have a chance to look this over before I do.~~

